### PR TITLE
Use a compatible version of authx with FastAPI.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 uvicorn
 requests
-authx
+authx==0.9.1


### PR DESCRIPTION
The problem with the [Pydantic](https://pypi.org/search/?c=Framework+%3A%3A+Pydantic), which has been resolved in a more recent version of authx.